### PR TITLE
added remaining permission cases to hasPermissions

### DIFF
--- a/components/classroom/groups/__test__.mjs
+++ b/components/classroom/groups/__test__.mjs
@@ -83,20 +83,36 @@ describe('hasPermission function',() => {
         expect(hasPermissions('CONTRIBUTOR', 'DELETE', '*', 'LINE')).toBe(true);
     });
     test('CONTRIBUTOR can UPDATE DESCRIPTION on LAYER', () => {
-        expect(hasPermissions('CONTRIBUTOR', 'UPDATE', 'DESCRIPTION', 'LAYER')).toBe(true);
+        expect(hasPermissions('CONTRIBUTOR', 'UPDATE', 'DESCRIPTION', 'LAYER')).toBe(true); 
     });
     test('CONTRIBUTOR cannot UPDATE DESCRIPTION on PAGE', () => {
         expect(hasPermissions('CONTRIBUTOR', 'UPDATE', 'DESCRIPTION', 'PAGE')).toBe(false);
     });
-    test('LEADER can READ a MEMBER', () => {
-        expect(hasPermissions('LEADER', 'READ', '*', 'MEMBER')).toBe(true);
+    test('LEADER cannot UPDATE a MEMBER', () => {
+        expect(hasPermissions('LEADER', 'UPDATE', '*', 'MEMBER')).toBe(true); 
     });
     test('LEADER can perform any action to METADATA of PERMISSION', () => {
-        expect(hasPermissions('LEADER','*','METADATA','PERMISSION')).toBe(true);
+        expect(hasPermissions('LEADER','*','METADATA','PERMISSION')).toBe(true); 
     });
-    test('OWNER can perform any action on any entity', () => {
+    test('OWNER can perform any action on any entity', () => { 
         expect(hasPermissions('OWNER', 'UPDATE', '*', '*')).toBe(true);
         expect(hasPermissions('OWNER', 'DELETE', '*', '*')).toBe(true);
         expect(hasPermissions('OWNER', 'READ', '*', '*')).toBe(true);
     });
+    test('CONTRIBUTOR can UPDATE the ORDER of any entity', () => {
+        expect(hasPermissions('CONTRIBUTOR','UPDATE','ORDER','*')).toBe(true); 
+    });
+    test('OWNER can CREATE any entity', () => {
+        expect(hasPermissions('OWNER','CREATE','*','*')).toBe(true);
+    });
+    test('CONTRIBUTOR cannot DELETE every entity', () => {
+        expect(hasPermissions('CONTRIBUTOR','DELETE','*','*')).toBe(false);
+    });
+    test('OWNER can perform any action on the SELECTOR of any entity', () => {
+        expect(hasPermissions('OWNER','*','SELECTOR','*')).toBe(true);
+    });
+    test('OWNER can perform any action on a ROLE', () => {
+        expect(hasPermissions('OWNER','*','*','ROLE')).toBe(true);
+    });
+    
 });

--- a/components/classroom/groups/checkPermissions.mjs
+++ b/components/classroom/groups/checkPermissions.mjs
@@ -18,6 +18,18 @@ function hasPermission(role, action, scope, entity){ //function checks if role d
     if(rolePermissions.includes(`${action}_*_${entity}`)){//if role has a permission with specified action and entity, and any scope
         return true;
     }
+    if(rolePermissions.includes(`${action}_${scope}_*`)){ //if role has a permission with specified action and scope with any entity
+        return true;
+    }
+    if(rolePermissions.includes(`${action}_*_*`)){ 
+        return true;
+    }
+    if(rolePermissions.includes(`*_${scope}_*`)){
+        return true;
+    }
+    if(rolePermissions.includes(`*_*_${entity}`)){ 
+        return true;
+    }
 
     return false; //if none of the if conditions satisfy
 }

--- a/components/classroom/groups/checkPermissions.mjs
+++ b/components/classroom/groups/checkPermissions.mjs
@@ -1,24 +1,34 @@
 import Roles from "./roles.mjs"
 import {Permissions} from "./permissions.mjs"
 
-function hasPermission(role, action, scope, entity){ //function checks if role definition meets permissions
-    if (!Permissions[Roles[role]]) return false; //if role does not exist, return false
+/**
+ * Checks if a role has permission for a specific action on an entity 
+ * within a given scope, considering various permission patterns.
+ * @param {string} role - The role to be checked.
+ * @param {string} action - The action being requested.
+ * @param {string} scope - The scope being requested.
+ * @param {string} entity - The entity being requested.
+ * @return - boolean value, true if role has permission and false otherwise
+ */
+
+function hasPermission(role, action, scope, entity){
+    if (!Permissions[Roles[role]]) return false; 
 
     let rolePermissions = Permissions[Roles[role]];
     
-    if(rolePermissions.includes(`${action}_${scope}_${entity}`)){ //if role has a permission with all 3 inputs
+    if(rolePermissions.includes(`${action}_${scope}_${entity}`)){ 
         return true;
     }
-    if(rolePermissions.includes('*_*_*')){ //if role has a permission that applies to all inputs
+    if(rolePermissions.includes('*_*_*')){
         return true;
     }
-    if(rolePermissions.includes(`*_${scope}_${entity}`)){ //if role has a permission with specified scope and entity, and any action
+    if(rolePermissions.includes(`*_${scope}_${entity}`)){
         return true;
     }
-    if(rolePermissions.includes(`${action}_*_${entity}`)){//if role has a permission with specified action and entity, and any scope
+    if(rolePermissions.includes(`${action}_*_${entity}`)){
         return true;
     }
-    if(rolePermissions.includes(`${action}_${scope}_*`)){ //if role has a permission with specified action and scope with any entity
+    if(rolePermissions.includes(`${action}_${scope}_*`)){ 
         return true;
     }
     if(rolePermissions.includes(`${action}_*_*`)){ 
@@ -31,7 +41,7 @@ function hasPermission(role, action, scope, entity){ //function checks if role d
         return true;
     }
 
-    return false; //if none of the if conditions satisfy
+    return false;
 }
 
 module.exports = hasPermission;


### PR DESCRIPTION
Fixes #21 

What was changed: Our function that tests permissions of a role now checks for every possible combination of action, scope, and entity.
Why it was changed: We needed our function to be able to cover all current permission cases as well as any other possibilities, leaving more flexibility for permissions added in the future.
How was it changed: Added 4 more if conditionals to the hasPermissions function in checkPermissions.mjs, as well as corresponding tests in __test__.mjs.
