### PR TITLE
altered getProjects to parse and return contributors

### DIFF
--- a/components/classroom/fetchData.mjs
+++ b/components/classroom/fetchData.mjs
@@ -1,7 +1,8 @@
 import TPEN from '../../TPEN/index.mjs';
 
+const PROJECT_FORM = document.getElementById("projectId");
+
 async function fetchProjectData(projectId) {
-    const PROJECT_FORM = document.getElementById(projectId);
     PROJECT_FORM.TPEN = new TPEN();
     TPEN.attachAuthentication(PROJECT_FORM);
 
@@ -15,9 +16,21 @@ async function fetchProjectData(projectId) {
                 'Authorization': `Bearer ${token}`
             }
         })
-            .then(res => res.ok ? res.json() : Promise.reject(res.status))
-            .then(data => msg.innerHTML = `<pre>${JSON.stringify(data, null, 2)}</pre>`)
-            .catch(err => msg.innerHTML = `<pre>${JSON.stringify(err, null, 2)}</pre>`);
+        .then(res => res.ok ? res.json() : Promise.reject(res.status))
+        .then(data => {
+            // Extract all collaborators without filtering
+            const collaborators = Object.entries(data.collaborators || {}).map(([key, value]) => ({
+                id: key,
+                name: value.profile.displayName,
+                roles: value.roles
+            }));
+        
+            // Display all collaborators in msg
+            msg.innerHTML = `<pre>${JSON.stringify(collaborators, null, 2)}</pre>`;
+        })
+        .catch(err => msg.innerHTML = `<pre>${JSON.stringify(err, null, 2)}</pre>`);
+        
+        
     }
 
     PROJECT_FORM.addEventListener('submit', async function (event) {
@@ -32,3 +45,6 @@ async function fetchProjectData(projectId) {
         }
     });
 }
+
+fetchProjectData(PROJECT_FORM);
+

--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -39,11 +39,6 @@
             <li><a href="./index.html">Contact</a></li>
         </ul>
     </div>
-
-    <div id="contributorDetails">
-        <h2>Contributor Details</h2>
-        <ul id="contributorsList"></ul>
-    </div>
     
 
     <div class="page-container">

--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -40,6 +40,12 @@
         </ul>
     </div>
 
+    <div id="contributorDetails">
+        <h2>Contributor Details</h2>
+        <ul id="contributorsList"></ul>
+    </div>
+    
+
     <div class="page-container">
         <h1>Welcome!</h1>
         <div class="input-container">


### PR DESCRIPTION
Fixes #38 

What was changed: Altered the functionality of fetching projects to also fetch contributors and attach it to the projects object. This is done by fetching the contributors through the API. The rendering is also updated to account for displaying contributors.
Why was it changed: The previous getProjects function did not account for displaying contributor data for a project.
How was it changed: 
-  in the index.mjs: 
- render(): updated render function to include contributor formatting
- getProjects(): attaches contributor data to projects object
- fetchContributors(): assists getProjects() by handling the fetch contributor logic
- managePermissions: this is not fully implemented as there are issues with getting projectData to show up at all because of log-in issues. for now, it displays an alert with the contributor ID because login issues are preventing project data from loading properly.