### PR TITLE
Added functionality for custom roles and permissions

### DIFF
--- a/components/classroom/README.md
+++ b/components/classroom/README.md
@@ -44,3 +44,30 @@ For a classroom group interface, the following APIs might be useful:
 2. **Project Collaboration API**: To manage group projects, track contributions, and facilitate collaborative work.
 3. **Annotation API**: To allow students to annotate and comment on manuscript images.
 4. **Export API**: To enable students to export their work in various formats for presentations or further study.
+
+# T-PEN Classroom Interface
+
+This folder (TPEN-Interfaces/components/classroom) contains code for a TPEN Classroom interface, meant to organize transcription users within a classroom setting.
+
+## Roles and Permissions
+
+Roles and permissions for users are defined within the `groups` folder. These determine what entities, actions, and scopes specific users have access to within the classroom group.
+
+* `roles.mjs`: defines a Roles object, made of 3 separate roles:
+    1. OWNER
+    2. LEADER
+    3. CONTRIBUTOR
+* `permissions_parameters.mjs`: defines 3 objects and their corresponding permissions:
+    1. `ACTION`: READ, UPDATE, DELETE, CREATE, ALL
+    2. `SCOPE`: METADATA, TEXT, ORDER, SELECTOR, DESCRIPTION, ALL
+    3. `ENTITIES`: PROJECT, MEMBER, LAYER, PAGE, LINE, ROLE, PERMISSION, ALL
+* `permissions.mjs`:
+    - The `Permissions` object contains the specific permissions granted to each role, with each permission in string format 'ACTION_SCOPE_ENTITY'.
+    - `generatePatterns(action, scope, entity)`: returns specific string patterns of permissions using an input of action, scope, and entity.
+    - `checkPermissions(role, action, scope, entity)`: validates whether a specific role can perform an action on a particular entity and scope.
+    - `createCustomRole(role)`: creates a custom role based on input to be added to the Roles object.
+    - `addPermission(role,action,scope,entity)`: adds a new permission to a specific role in Permissions using the predefined actions, scopes, and entities.
+* `checkPermissions.mjs`: contains function `hasPermission(role, action, scope, entity)`, which checks if a role has permission for a specific action on an entity within a given scope, considering various permission patterns.
+
+## Fetching Accounts and Projects
+The TPEN API is utilized within `fetchData.mjs` to retrieve project data and its corresponding users based on project ID. To display this data, the `ClassroomGroup` component within `web-component.js` is called and displayed within the classroom interface's homepage `index.html`. Users are authorized with the `AuthButton` component within `auth-button.js`.

--- a/components/classroom/groups/__test__.mjs
+++ b/components/classroom/groups/__test__.mjs
@@ -116,3 +116,47 @@ describe('hasPermission function',() => {
     });
     
 });
+
+describe('createCustomRole function',() => {
+    let mockRoles;
+    let mockPermissions;
+    
+    beforeEach(() => {
+        mockRoles = {};
+        mockPermissions = {};
+    });
+
+    test('Successfully add custom role GUEST', () => {
+        Object.assign(Roles, mockRoles);
+        Object.assign(Permissions, mockPermissions);
+        createCustomRole('GUEST');
+        expect(mockRoles.GUEST).toBe('GUEST');
+        expect(mockPermissions.admin).toBeNull();
+    });
+
+    test('Unsuccessfully adds LEADER role', () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+        Object.assign(Roles, mockRoles);
+        Object.assign(Permissions, mockPermissions);
+        createCustomRole('LEADER');
+        expect(logSpy).toHaveBeenCalledWith('Role already exists.');
+        logSpy.mockRestore();
+    
+    });
+    
+    test('Unsuccessfully adds non-string role', () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+        Object.assign(Roles, mockRoles);
+        Object.assign(Permissions, mockPermissions);
+        let role = 123;
+        createCustomRole(role);
+        expect(logSpy).toHaveBeenCalledWith('Input needs to be of type string.');
+        logSpy.mockRestore();
+
+    });
+
+    afterEach(() => {
+        Object.keys(mockRoles).forEach(key => delete Roles[key]);
+        Object.keys(mockPermissions).forEach(key => delete Permissions[key]);
+    });
+});

--- a/components/classroom/groups/__test__.mjs
+++ b/components/classroom/groups/__test__.mjs
@@ -1,6 +1,6 @@
-const Roles = require('./roles');
+const {Roles} = require('./roles');
 const { Action, Scope, Entity } = require('./permissions_parameters');
-const {checkPermissions} = require('./permissions.mjs');
+const {Permissions,checkPermissions,createCustomRole,addPermission} = require('./permissions.mjs');
 const hasPermissions = require('./checkPermissions.mjs');
 
 const testProperties = (obj, properties) => {
@@ -118,45 +118,62 @@ describe('hasPermission function',() => {
 });
 
 describe('createCustomRole function',() => {
-    let mockRoles;
-    let mockPermissions;
-    
-    beforeEach(() => {
-        mockRoles = {};
-        mockPermissions = {};
-    });
 
     test('Successfully add custom role GUEST', () => {
-        Object.assign(Roles, mockRoles);
-        Object.assign(Permissions, mockPermissions);
         createCustomRole('GUEST');
-        expect(mockRoles.GUEST).toBe('GUEST');
-        expect(mockPermissions.admin).toBeNull();
+        expect(Roles.GUEST).toBe('GUEST');
+        expect(Permissions[[Roles.GUEST]]).toEqual([]);
     });
 
     test('Unsuccessfully adds LEADER role', () => {
         const logSpy = jest.spyOn(global.console, 'log');
-        Object.assign(Roles, mockRoles);
-        Object.assign(Permissions, mockPermissions);
         createCustomRole('LEADER');
         expect(logSpy).toHaveBeenCalledWith('Role already exists.');
         logSpy.mockRestore();
-    
     });
     
     test('Unsuccessfully adds non-string role', () => {
         const logSpy = jest.spyOn(global.console, 'log');
-        Object.assign(Roles, mockRoles);
-        Object.assign(Permissions, mockPermissions);
         let role = 123;
         createCustomRole(role);
         expect(logSpy).toHaveBeenCalledWith('Input needs to be of type string.');
         logSpy.mockRestore();
-
     });
 
-    afterEach(() => {
-        Object.keys(mockRoles).forEach(key => delete Roles[key]);
-        Object.keys(mockPermissions).forEach(key => delete Permissions[key]);
+});
+
+describe('addPermission function',() => {
+
+    test('Add permission to existing role', () => {
+        addPermission('CONTRIBUTOR','CREATE','TEXT','ROLE');
+        expect(Permissions[[Roles.CONTRIBUTOR]]).toContain('CREATE_TEXT_ROLE');
+    });
+
+    test('Add permission to custom role', () => {
+        createCustomRole('GUEST');
+        addPermission('GUEST','READ','ALL','ALL');
+        expect(Permissions[[Roles.GUEST]]).toContain('READ_*_*');
+    });
+
+    test('Unsuccessfully adds to non-existing role', () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+        addPermission('TEST','READ','ALL','ALL')
+        expect(logSpy).toHaveBeenCalledWith('Cannot find role.');
+        logSpy.mockRestore();
+    });
+    
+    test('Unsuccessfully adds non-string permission', () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+        let scope = 123;
+        addPermission('CONTRIBUTOR','READ',scope,'ALL')
+        expect(logSpy).toHaveBeenCalledWith('All inputs are required to be of type string.');
+        logSpy.mockRestore();
+    });
+
+    test('Unsuccessfully adds already existing permission', () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+        addPermission('OWNER','READ','ALL','ALL')
+        expect(logSpy).toHaveBeenCalledWith('Role already encompasses specified permission.');
+        logSpy.mockRestore();
     });
 });

--- a/components/classroom/groups/checkPermissions.mjs
+++ b/components/classroom/groups/checkPermissions.mjs
@@ -1,4 +1,4 @@
-import Roles from "./roles.mjs"
+import {Roles} from "./roles.mjs"
 import {Permissions} from "./permissions.mjs"
 
 /**

--- a/components/classroom/groups/permissions.mjs
+++ b/components/classroom/groups/permissions.mjs
@@ -1,6 +1,6 @@
 import { Roles } from "./roles.mjs"
 import {Action,Scope,Entity} from "./permissions_parameters.mjs"
-import {hasPermission} from "./checkPermissions.mjs"
+const hasPermission = require('./checkPermissions.mjs');
 
 export const Permissions = {
     [Roles.OWNER]: ['*_*_*'],
@@ -61,12 +61,12 @@ export function createCustomRole(role){
         console.log("Input needs to be of type string.");
         return;
     }
-    if (Permissions[role]){
+    if (Roles[role]){
         console.log("Role already exists.");
         return;
     }
-    Object.defineProperty(Roles,role,{value:role}); //adding role to role object in roles.mjs
-    Object.defineProperty(Permissions,role,{value:null});
+    Object.defineProperty(Roles,role,{value:role,writable:true,enumerable:true,configurable:true}); //adding role to role object in roles.mjs
+    Object.defineProperty(Permissions,role,{value:[],writable:true,enumerable:true,configurable:true}); //adding role to Permissions const
     }
 
 export function addPermission(role,action,scope,entity){
@@ -110,5 +110,5 @@ export function addPermission(role,action,scope,entity){
         return;
     }
 
-    Object.defineProperty(Permissions,[Roles.role],{value:`${action}_${scope}_${entity}`});
+    Object.defineProperty(Permissions,Roles[role],{value:`${action}_${scope}_${entity}`,writable:true,enumerable:true,configurable:true});
 }

--- a/components/classroom/groups/permissions.mjs
+++ b/components/classroom/groups/permissions.mjs
@@ -1,4 +1,7 @@
 import { Roles } from "./roles.mjs"
+import {Action,Scope,Entity} from "./permissions_parameters.mjs"
+import {hasPermission} from "./checkPermissions.mjs"
+
 export const Permissions = {
     [Roles.OWNER]: ['*_*_*'],
     [Roles.LEADER]: [
@@ -49,3 +52,63 @@ export function checkPermissions(role, action, scope, entity) {
     // Check if any pattern matches the role's permissions
     return patterns.some(pattern => rolePerms.includes(pattern));
 };
+
+//can we combine checkPermissions with permissions here?
+//we also need a function to assign permissions to a user object once we have that class defined (no user attributes or anything to assign right now, just a lot of constants)
+
+export function createCustomRole(role){ 
+    if(typeof role!="string"){
+        console.log("Input needs to be of type string.");
+        return;
+    }
+    if (Permissions[role]){
+        console.log("Role already exists.");
+        return;
+    }
+    Object.defineProperty(Roles,role,{value:role}); //adding role to role object in roles.mjs
+    Object.defineProperty(Permissions,role,{value:null});
+    }
+
+export function addPermission(role,action,scope,entity){
+    if(typeof role!="string"||typeof action!="string"||typeof scope!="string"||typeof entity!="string"){
+        console.log("All inputs are required to be of type string.");
+        return;
+    }
+    if (!Permissions[role]){
+        console.log("Cannot find role.");
+        return;
+    }
+
+    let definedActions = Object.values(Action);
+    let definedScopes = Object.values(Scope);
+    let definedEntities = Object.values(Entity);
+
+    if(definedActions.includes(action)==false){
+        console.log("Action input is not a valid action.");
+        return;
+    }
+    if(definedScopes.includes(scope)==false){
+        console.log("Scope input is not a valid scope.");
+        return;
+    }
+    if(definedEntities.includes(entity)==false){
+        console.log("Entity input is not a valid entity.");
+        return;
+    }
+
+    if(action=="ALL"){
+        action="*"
+    }
+    if(scope=="ALL"){
+        scope="*"
+    }
+    if(entity=="ALL"){
+        entity="*"
+    }
+    if(hasPermission(role,action,scope,entity)){
+        console.log("Role already encompasses specified permission.");
+        return;
+    }
+
+    Object.defineProperty(Permissions,[Roles.role],{value:`${action}_${scope}_${entity}`});
+}


### PR DESCRIPTION
Fixes #40 

What was changed: Our program now has the functionality to add new roles and permissions to our existing objects.

Why it was changed: This allows the classroom interface to have more flexibility with the existing structure and make it more adaptable to each unique classroom.

How it was changed: permissions.mjs now has two more functions: createCustomRole(), which allows for adding a new role to the Roles.mjs object, and addPermission(), which adds a new permission to a role attribute within the Permissions object. A total of 8 test cases were created for these two functions. A bug that caused many previous test cases to fail was also fixed.