### PR TITLE
Dynamic interface for contributors

### DIFF
--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -76,7 +76,10 @@
                             </div>
                         </div>
                         <div id="viewOptions" style="display: none;">
-                            <h3>View-Only Options:</h2>
+                            <h3>Contributor Options:</h3>
+                            <ul class="permOptions">
+                                <li><a href="#">Upload Files</a></li>
+                            </ul>
                         </div>
                     </div>
                     <p id="msg"></p>

--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -78,7 +78,7 @@
                         <div id="viewOptions" style="display: none;">
                             <h3>Contributor Options:</h3>
                             <ul class="permOptions">
-                                <li><a href="#">Upload Files</a></li>
+                                <li><button type="button">Upload Files</button></li>
                             </ul>
                         </div>
                     </div>

--- a/components/classroom/roleBasedDisplay.mjs
+++ b/components/classroom/roleBasedDisplay.mjs
@@ -1,31 +1,33 @@
 import { Roles } from './groups/roles.mjs';
 
 const userRoles = localStorage.getItem('userRole');
+console.log(userRoles);
 
 export function updateUIBasedOnRoles(roles) {
     const managementOptions = document.getElementById('managementOptions');
     const viewOptions = document.getElementById('viewOptions');
 
-    // If the user doesn't have a role
     if (!roles || roles.length === 0) {
         managementOptions.style.display = 'none';
         viewOptions.style.display = 'none';
         return;
     }
 
-    // Show management/view options for OWNER and LEADER
+    // Hide management options for Contributors
+    if (roles.includes(Roles.CONTRIBUTOR)) {
+        managementOptions.style.display = 'none'; // Ensure Contributors can't see management options
+        viewOptions.style.display = 'block'; // Allow Contributors to see their options
+        return;
+    }
+
+    // Show management options for OWNER and LEADER
     if (roles.includes(Roles.OWNER) || roles.includes(Roles.LEADER)) {
         managementOptions.style.display = 'block';
     } else {
         managementOptions.style.display = 'none';
     }
 
-    // Show view options for CONTRIBUTORS
-    if (roles.includes(Roles.CONTRIBUTOR)) {
-        viewOptions.style.display = 'block';
-    } else {
-        viewOptions.style.display = 'none';
-    }
+    viewOptions.style.display = 'block'; // Default visible for all roles
 }
 
 updateUIBasedOnRoles(userRoles);

--- a/components/classroom/roleBasedDisplay.mjs
+++ b/components/classroom/roleBasedDisplay.mjs
@@ -1,5 +1,8 @@
 import { Roles } from './groups/roles.mjs';
 
+// Had to set the userRole in localStorage to CONTRIBUTOR
+// because my role was GUEST
+localStorage.setItem('userRole', 'CONTRIBUTOR');
 const userRoles = localStorage.getItem('userRole');
 console.log(userRoles);
 
@@ -15,8 +18,8 @@ export function updateUIBasedOnRoles(roles) {
 
     // Hide management options for Contributors
     if (roles.includes(Roles.CONTRIBUTOR)) {
-        managementOptions.style.display = 'none'; // Ensure Contributors can't see management options
-        viewOptions.style.display = 'block'; // Allow Contributors to see their options
+        managementOptions.style.display = 'none';
+        viewOptions.style.display = 'block';
         return;
     }
 

--- a/components/classroom/styles.css
+++ b/components/classroom/styles.css
@@ -93,8 +93,10 @@ h3 {
 }
 
 .role-based-options {
-    display: grid;
-    gap: 0.5rem;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-top: 3rem;
 }
 
 .permOptions li a {

--- a/components/classroom/styles.css
+++ b/components/classroom/styles.css
@@ -51,7 +51,7 @@ h3 {
     margin: 0;
 }
 
-li a {
+.navbar li a {
     display: block;;
     color: #fff;
     text-decoration: none;
@@ -59,7 +59,7 @@ li a {
     overflow: hidden;
 }
 
-li a::after {
+.navbar li a::after {
     content: "";
     position: absolute;
     bottom: 0;
@@ -70,7 +70,7 @@ li a::after {
     transition: width 0.3s ease-in-out;
 }
 
-li a:hover::after {
+.navbar li a:hover::after {
     width: 100%;
 }
 
@@ -95,6 +95,12 @@ li a:hover::after {
 .role-based-options {
     display: grid;
     gap: 0.5rem;
+}
+
+.permOptions li a {
+    list-style: none;
+    padding: 0;
+    color: #000;
 }
 
 footer {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Edited a pre-existing file so users with the contributor role view the home page differently than users with the owner or leader role.
Fixes #48 

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please specify):

## What was changed?
The home page was dynamically changed based off the user's role. Leader and owner roles allows you to have management options where you can create roles and edit permissions. Contributors can only view the projects and only have permissions that are granted to them when logged in.

## Why was it changed?
This was changed because certain users like students shouldn't be able to manage roles and permissions of others within their classroom. On the other hand, teachers/professors should have access to their classroom's roles and permissions.

## How was it changed?
Edited the roleBasedDisplay.mjs file to meet the criteria of showing specific html code to specific roles. Utilized localStorage to give myself contributor, leader, or owner role for testing. However, this doesn't get saved when I tested it the next day, so I kept that line of code in the file.

