### PR TITLE
when contributor option is clicked, display block text

### DIFF
--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -124,30 +124,49 @@
                 list.project_id(input);
             }
 
-            document.addEventListener("DOMContentLoaded", function () {
-            const roleSelect = document.getElementById("roleSelect");
-
-            if (!roleSelect) {
-                console.error("roleSelect not found in the DOM!");
-                return;
-            }
-
-            roleSelect.addEventListener("change", function () {
-                const selectedRole = this.value;
+            document.addEventListener("DOMContentLoaded", async function () {
+                const roleSelect = document.getElementById("roleSelect");
                 const contributorOptions = document.getElementById("viewOptions");
+                let rolesData = {}; // Store JSON data
 
-                console.log("Role changed to:", selectedRole);           
-
-                if (selectedRole === "CONTRIBUTOR") {
-                    contributorOptions.style.display = "block";  // Show contributor options
-                    contributorOptions.innerHTML = "<p>Contributor Options Include: READ_MEMBER, UPDATE_TEXT, UPDATE_ORDER_, UPDATE_SELECTOR_, CREATE_SELECTOR_, DELETE_LINE, UPDATE_DESCRIPTION_LAYER, CREATE*_LAYER </p>"; 
-                    console.log("Contributor options are now visible");
-                } else {
-                    contributorOptions.style.display = "none";  // Hide contributor options
-                    console.log("Contributor options are now hidden");
+                async function loadRoles() {
+                    try {
+                        const response = await fetch('./groups/permissionsConfig.json');
+                        if (!response.ok) throw new Error("Failed to load permissionsConfig.json");
+                        rolesData = await response.json(); 
+                    } catch (error) {
+                        rolesData = {};
+                    }
                 }
+
+                await loadRoles();
+
+                roleSelect.addEventListener("change", function () {
+                    const selectedRole = this.value;
+                    console.log("🔄 Role changed to:", selectedRole);
+
+                    fetch('./config/permissionsConfig.json')
+                        .then(response => response.json())
+                        .then(data => {
+                            console.log("Loaded JSON Data:", data);
+                        })
+                        .catch(error => console.error("Error loading JSON:", error));
+
+                    if (selectedRole === "CONTRIBUTOR") {
+                        if (rolesData.CONTRIBUTOR) {
+                            contributorOptions.style.display = "block";
+                            contributorOptions.innerHTML = `
+                                <h3>Contributor Options</h3>
+                                <ul>
+                                    ${rolesData.CONTRIBUTOR.map(permission => `<li>${permission}</li>`).join("")}
+                                </ul>
+                            `;
+                        } else {
+                            contributorOptions.style.display = "none";
+                        }
+                    }
+                });
             });
-        });
         </script>
     </body>
 </html>

--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -124,6 +124,30 @@
                 list.project_id(input);
             }
 
+            document.addEventListener("DOMContentLoaded", function () {
+            const roleSelect = document.getElementById("roleSelect");
+
+            if (!roleSelect) {
+                console.error("❌ roleSelect not found in the DOM!");
+                return;
+            }
+
+            roleSelect.addEventListener("change", function () {
+                const selectedRole = this.value;
+                const contributorOptions = document.getElementById("viewOptions");
+
+                console.log("Role changed to:", selectedRole);           
+
+                if (selectedRole === "CONTRIBUTOR") {
+                    contributorOptions.style.display = "block";  // Show contributor options
+                    contributorOptions.innerHTML = "<p>Contributor options are now visible</p>"; 
+                    console.log("Contributor options are now visible");
+                } else {
+                    contributorOptions.style.display = "none";  // Hide contributor options
+                    console.log("Contributor options are now hidden");
+                }
+            });
+        });
         </script>
     </body>
 </html>

--- a/components/classroom/index.html
+++ b/components/classroom/index.html
@@ -128,7 +128,7 @@
             const roleSelect = document.getElementById("roleSelect");
 
             if (!roleSelect) {
-                console.error("❌ roleSelect not found in the DOM!");
+                console.error("roleSelect not found in the DOM!");
                 return;
             }
 
@@ -140,7 +140,7 @@
 
                 if (selectedRole === "CONTRIBUTOR") {
                     contributorOptions.style.display = "block";  // Show contributor options
-                    contributorOptions.innerHTML = "<p>Contributor options are now visible</p>"; 
+                    contributorOptions.innerHTML = "<p>Contributor Options Include: READ_MEMBER, UPDATE_TEXT, UPDATE_ORDER_, UPDATE_SELECTOR_, CREATE_SELECTOR_, DELETE_LINE, UPDATE_DESCRIPTION_LAYER, CREATE*_LAYER </p>"; 
                     console.log("Contributor options are now visible");
                 } else {
                     contributorOptions.style.display = "none";  // Hide contributor options


### PR DESCRIPTION
## Description
Fixes #61 

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please specify):

## What was changed?
From the role drop-down menu, when the contributor option is clicked, the contributor options display. However, I am unsure what constitutes as contributor options, so for now, it displays placeholder text.

## Why was it changed?
This change allows the user to see what they are allowed to do as a contributor.

## How was it changed?
The index.html was refactored to include an event listener so when the contributor option is clicked a display block appears in the html.


<img width="1438" alt="Screenshot 2025-03-03 at 12 25 53 PM" src="https://github.com/user-attachments/assets/4d81113d-95cd-404b-a2fb-88a9aa703c2b" />
