### PR TITLE
created endpoints and role options

### DIFF
--- a/components/classroom/fetchData.mjs
+++ b/components/classroom/fetchData.mjs
@@ -40,46 +40,15 @@ async function fetchProjectData(projectId) {
     }
 }
 
-document.getElementById("clickList").addEventListener("click", async function (event) {
+document.getElementById("clickList").addEventListener("click", function (event) {
     const LI = event.target.closest("#clickList li");
-    if (LI) {
-        const projectID = LI.getAttribute("tpen-project-id");
-        console.log(`Project clicked: Fetching details for Project ID: ${projectID}`);
+    if (!LI) return;
 
-        if (!projectID) {
-            console.error("No project ID found!");
-            return;
-        }
+    const projectID = LI.getAttribute("tpen-project-id");
+    if (!projectID) return;
 
-        try {
-            const projectData = await fetchProjectData(projectID);
-            console.log("Project data fetched:", projectData);
-
-            if (!projectData) {
-                console.error("No project data returned!");
-                MSG_CONTAINER.innerHTML = `<p style="color: red;">No project data available.</p>`;
-                return;
-            }
-
-            const userRoles = Object.keys(projectData.roles || {}).join(", ");
-
-            const rolesDisplay = userRoles ? `<p><strong>Roles:</strong> ${userRoles}</p>` : "<p>No assigned roles</p>";
-            
-            MSG_CONTAINER.innerHTML = `
-                <p><strong>Project ID: </strong> ${projectData._id || "Unknown"}</p>
-                ${rolesDisplay}
-                <p><strong>Permissions:</strong> ${
-                    Array.isArray(projectData.permissions) 
-                        ? projectData.permissions.join(", ") 
-                        : "No permissions available"
-                }</p>
-            `;
-
-        } catch (error) {
-            console.error("Error fetching project data:", error);
-            MSG_CONTAINER.innerHTML = `<p style="color: red;">Error: ${error.message}</p>`;
-        }
-    }
+    // Redirect to new page
+    window.location.href = `project.html?projectID=${projectID}`;
 });
 
 fetchProjectData(PROJECT_FORM);

--- a/components/classroom/project.html
+++ b/components/classroom/project.html
@@ -1,17 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Classroom Page</title>
-    </head>
-    <body>
-        <h1>Classroom Group Management</h1>
-        <p id="project-info">Project ID: </p>
-        <p id="project-name">Project Name: </p>
-        <p id="project-creator">Project Creator: </p>
+<head>
+  <meta charset="UTF-8">
+  <title>Classroom Group Options</title>
+</head>
+<body>
+  <h1>Classroom Group Options</h1>
+  <div id="role-options"></div>
 
-        <script type="module" src="main.js"></script>
-
-    </body>
+  <script type="module" src="./projectPage.mjs"></script>
+</body>
 </html>

--- a/components/classroom/projectPage.mjs
+++ b/components/classroom/projectPage.mjs
@@ -1,0 +1,51 @@
+import TPEN from '../../TPEN/index.mjs';
+
+document.addEventListener("DOMContentLoaded", async () => {
+  const projectId = new URLSearchParams(window.location.search).get("projectID");
+
+  if (!projectId) {
+    document.body.innerHTML = "<p style='color:red;'>Missing project ID in URL.</p>";
+    return;
+  }
+
+  try {
+    const token = TPEN.getAuthorization();
+    const response = await fetch(`${TPEN.servicesURL}/project/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    const projectData = await response.json();
+    
+    if (!projectData || !projectData._id) {
+      throw new Error("Invalid or missing project data");
+    }
+
+    console.log("Project Data:", projectData);
+
+    const roles = Object.keys(projectData.roles || {});
+    const container = document.createElement("div");
+
+    if (roles.includes("OWNER") || roles.includes("LEADER")) {
+        
+      container.innerHTML = `
+        <button>Invite New Members</button>
+        <button>Manage Roster</button>
+        <button>Manage Roles</button>
+      `;
+    } else if (roles.includes("CONTRIBUTOR")) {
+      container.innerHTML = `
+        <button>Upload Assignments</button>
+        <button>Transcription</button>
+        <button>Gradebook</button>
+      `;
+    } else {
+      container.innerHTML = "<p>You have no special permissions in this project.</p>";
+    }
+
+    document.body.appendChild(container);
+
+  } catch (err) {
+    console.error("Something went wrong:", err);
+    document.body.innerHTML = "<p style='color:red;'>Something went wrong. Try again.</p>";
+  }
+});

--- a/components/classroom/projectPage.mjs
+++ b/components/classroom/projectPage.mjs
@@ -23,21 +23,26 @@ document.addEventListener("DOMContentLoaded", async () => {
     console.log("Project Data:", projectData);
     window.projectData = projectData;
 
-    const userID = Object.keys(projectData.collaborators).find(
-      id => projectData.collaborators[id].profile?.displayName === "sarah.fidahussain"
+    // Try to get the user ID from TPEN, fallback to matching the first ID with a displayName
+    let userID = TPEN?.currentUser?._id;
+
+    if (!userID) {
+      userID = Object.keys(projectData.collaborators).find(
+        id => projectData.collaborators[id].profile?.displayName
       );
+    }
 
     const user = projectData.collaborators?.[userID];
     const roles = user?.roles || [];
 
     console.log("User Roles:", roles);
 
-    // Label to show user roles
+    // Show the roles on screen
     const roleDisplay = document.createElement("p");
     roleDisplay.textContent = `Roles: ${roles.join(", ")}`;
     document.body.appendChild(roleDisplay);
 
-    // Build role-specific buttons
+    // Build buttons based on roles
     let buttonsHTML = "";
 
     if (roles.includes("OWNER") || roles.includes("LEADER")) {
@@ -70,4 +75,3 @@ document.addEventListener("DOMContentLoaded", async () => {
     document.body.innerHTML = "<p style='color:red;'>Something went wrong. Try again.</p>";
   }
 });
-

--- a/components/classroom/projectPage.mjs
+++ b/components/classroom/projectPage.mjs
@@ -21,27 +21,48 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     console.log("Project Data:", projectData);
+    window.projectData = projectData;
 
-    const roles = Object.keys(projectData.roles || {});
-    const container = document.createElement("div");
+    const userID = Object.keys(projectData.collaborators).find(
+      id => projectData.collaborators[id].profile?.displayName === "sarah.fidahussain"
+      );
+
+    const user = projectData.collaborators?.[userID];
+    const roles = user?.roles || [];
+
+    console.log("User Roles:", roles);
+
+    // Label to show user roles
+    const roleDisplay = document.createElement("p");
+    roleDisplay.textContent = `Roles: ${roles.join(", ")}`;
+    document.body.appendChild(roleDisplay);
+
+    // Build role-specific buttons
+    let buttonsHTML = "";
 
     if (roles.includes("OWNER") || roles.includes("LEADER")) {
-        
-      container.innerHTML = `
+      buttonsHTML += `
         <button>Invite New Members</button>
         <button>Manage Roster</button>
         <button>Manage Roles</button>
       `;
-    } else if (roles.includes("CONTRIBUTOR")) {
-      container.innerHTML = `
+    }
+
+    if (roles.includes("CONTRIBUTOR")) {
+      buttonsHTML += `
         <button>Upload Assignments</button>
         <button>Transcription</button>
         <button>Gradebook</button>
       `;
-    } else {
-      container.innerHTML = "<p>You have no special permissions in this project.</p>";
     }
 
+    if (!buttonsHTML) {
+      buttonsHTML = "<p>You have no special permissions in this project.</p>";
+    }
+
+    const container = document.createElement("div");
+    container.style.marginTop = "1rem";
+    container.innerHTML = buttonsHTML;
     document.body.appendChild(container);
 
   } catch (err) {
@@ -49,3 +70,4 @@ document.addEventListener("DOMContentLoaded", async () => {
     document.body.innerHTML = "<p style='color:red;'>Something went wrong. Try again.</p>";
   }
 });
+


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Fixes #70 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [ ] Other (please specify):

## What was changed?
When clicking the project name, instead of project details appearing on the home page, it appears on a new page. There are buttons that have options that respect the user roles. 

## Why was it changed?
Before it just displayed project information. Now it will lead to options that the user can do to projects.

## How was it changed?
I altered fetchData.mjs so now it no longer displays project details, but instead it redirects the user to project.html and the user sees a new page with user options. I added a new file called ProjectPage.mjs which fetches project details like what roles the user has and displays the right role options. Project.html now displays structure according to projectPage.mjs. 

Below is an example of what it looks like on my end, because I have owner and leader roles it is displaying the following options. However, for the future, since I also have the contributor role to this project, should it also display contributor options?

![Screenshot 2025-03-23 at 10 30 50 PM](https://github.com/user-attachments/assets/1589140e-b1d8-4b22-aba6-ad2b50e7f582)
